### PR TITLE
update

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,9 @@
 PROJECT_NAME=my_wordpress_project
 PROJECT_BASE_URL=wp.docker.localhost
 
+TRAEFIK_HTTP=80
+TRAEFIK_DASHBOARD=8080
+
 DB_NAME=wordpress
 DB_USER=wordpress
 DB_PASSWORD=wordpress
@@ -111,3 +114,4 @@ OPENSMTPD_TAG=6.0-1.10.0
 RSYSLOG_TAG=latest
 WEBGRIND_TAG=1-1.21.1
 XHPROF_TAG=3.0.3
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.env
 .idea/
 mutagen.yml.lock

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -237,8 +237,8 @@ services:
     container_name: "${PROJECT_NAME}_traefik"
     command: --api.insecure=true --providers.docker
     ports:
-    - '8000:80'
-#    - '8080:8080' # Dashboard
+    - '${TRAEFIK_HTTP:-80}:80'
+    - '${TRAEFIK_DASHBOARD:-8080}:8080' # Dashboard
     volumes:
     - /var/run/docker.sock:/var/run/docker.sock
 


### PR DESCRIPTION
- Add configurable `treafic` ports
- remove and ignore `.env` in favor of `.env.example` for users to copy